### PR TITLE
Add some commands

### DIFF
--- a/lsp-mssql.el
+++ b/lsp-mssql.el
@@ -264,11 +264,11 @@ PARAMS the params."
                                         (- row-count loaded-index)
                                       to-load)))
                        `(:ownerUri ,owner-uri
-                                   :resultSetIndex ,id
-                                   :rowsCount ,to-load
-                                   :rowsStartIndex ,(prog1 loaded-index
-                                                      (setf loaded-index (+ loaded-index to-load)))
-                                   :batchIndex ,batchId))
+                         :resultSetIndex ,id
+                         :rowsCount ,to-load
+                         :rowsStartIndex ,(prog1 loaded-index
+                                            (setf loaded-index (+ loaded-index to-load)))
+                         :batchIndex ,batchId))
                    (lsp--info "All items are loaded")
                    nil)))
       (when-let ((params (subset-params)))

--- a/lsp-mssql.el
+++ b/lsp-mssql.el
@@ -309,7 +309,7 @@ PARAMS the params."
               (org-mode)
               (goto-char (marker-position marker))
               (org-table-align)
-              (pop-to-buffer (current-buffer))))
+              (display-buffer (current-buffer))))
            :mode 'detached))))))
 
 (defun lsp-mssql--batch-complete (_workspace _params)
@@ -344,7 +344,7 @@ PARAMS batch handler params."
      ;;                                                         ("character" endColumn))))))
      ;; (insert "#+END_SRC\n\n")
      )
-   (display-buffer-in-side-window  (current-buffer) '((side . bottom)))))
+   (display-buffer (current-buffer))))
 
 (defun lsp-mssql--connection-changed (_workspace _params)
   "Hanler for batch complete.")

--- a/lsp-mssql.el
+++ b/lsp-mssql.el
@@ -436,6 +436,11 @@ PARAMS batch handler params."
    (erase-buffer))
   (lsp-request "query/executeDocumentSelection" (list :ownerUri (lsp--buffer-uri))))
 
+(defun lsp-mssql-cancel ()
+  "Cancel the current query."
+  (interactive)
+  (lsp-request "query/cancel" (list :ownerUri (lsp--buffer-uri))))
+
 
 ;; object explorer
 


### PR DESCRIPTION
- `lsp-mssql-cancel` to cancel current query
- ~`lsp-mssql-format-region` to format the region~ this is already by default in lsp-mode

I also changed various display/pop commands to use `display-buffer` which is user-configurable via `display-buffer-alist`.  For example, I have multiple monitors and I want the result set to be shown (not selected) on the second one if the window is already visible there, such that I can keep editing the queries without having to switch back-and-forth between windows.