### PR TITLE
Disable profiles and check for v7+ when polling PowerShell version

### DIFF
--- a/lsp-mssql.el
+++ b/lsp-mssql.el
@@ -74,7 +74,7 @@ This is stored in the result buffer as buffer local value.")
    ((eq system-type 'windows-nt)
     ;; on windows, we attempt to use powershell v5+, available on Windows 10+
     (let ((powershell-version (substring
-                               (shell-command-to-string "powershell -command \"(Get-Host).Version.Major\"")
+                               (shell-command-to-string "powershell -noprofile -command \"(Get-Host).Version.Major\"")
                                0 -1)))
       (if (>= (string-to-number powershell-version) 5)
           (call-process "powershell"

--- a/lsp-mssql.el
+++ b/lsp-mssql.el
@@ -75,8 +75,12 @@ This is stored in the result buffer as buffer local value.")
     ;; on windows, we attempt to use powershell v5+, available on Windows 10+
     (let ((powershell-version (substring
                                (shell-command-to-string "powershell -noprofile -command \"(Get-Host).Version.Major\"")
+                               0 -1))
+		  ;; Powershell v7+ uses a different binary
+		  (pwsh-version (substring
+                               (shell-command-to-string "pwsh -noprofile -command \"(Get-Host).Version.Major\"")
                                0 -1)))
-      (if (>= (string-to-number powershell-version) 5)
+      (if (or (>= (string-to-number powershell-version) 5) (>= (string-to-number pwsh-version) 5))
           (call-process "powershell"
                         nil
                         nil


### PR DESCRIPTION
These two changes:

1. Disable the user's profile from being loaded when checking the PowerShell version. I ran into my profile generating errors in addition to the version number, which caused the check to fail.
2. Add a specific check for PowerShell v7+ [which uses a different binary](https://learn.microsoft.com/en-us/powershell/scripting/whats-new/migrating-from-windows-powershell-51-to-powershell-7?view=powershell-7.5#separate-installation-path-and-executable-name)