### PR TITLE
In Windows, use PowerShell v7+ if available; disable user profiles in commands

### DIFF
--- a/lsp-mssql.el
+++ b/lsp-mssql.el
@@ -76,12 +76,10 @@ This is stored in the result buffer as buffer local value.")
     (let ((powershell-version (substring
                                (shell-command-to-string "powershell -noprofile -command \"(Get-Host).Version.Major\"")
                                0 -1))
-		  ;; Powershell v7+ uses a different binary
-		  (pwsh-version (substring
-                               (shell-command-to-string "pwsh -noprofile -command \"(Get-Host).Version.Major\"")
-                               0 -1)))
-      (if (or (>= (string-to-number powershell-version) 5) (>= (string-to-number pwsh-version) 5))
-          (call-process "powershell"
+		  ;; If PowerShell v7+ is available, use that
+		  (powershell-binary (if (> (string-to-number pwsh-version) 0) "pwsh" "powershell")))
+      (if (or (>= (string-to-number powershell-version) 5) (string= powershell-binary "pwsh"))
+          (call-process powershell-binary
                         nil
                         nil
                         nil

--- a/lsp-mssql.el
+++ b/lsp-mssql.el
@@ -73,12 +73,15 @@ This is stored in the result buffer as buffer local value.")
   (cond
    ((eq system-type 'windows-nt)
     ;; on windows, we attempt to use powershell v5+, available on Windows 10+
-    (let ((powershell-version (substring
+    (let* ((powershell-version (substring
                                (shell-command-to-string "powershell -noprofile -command \"(Get-Host).Version.Major\"")
+                               0 -1))
+		  (pwsh-version (substring
+                               (shell-command-to-string "pwsh -noprofile -command \"(Get-Host).Version.Major\"")
                                0 -1))
 		  ;; If PowerShell v7+ is available, use that
 		  (powershell-binary (if (> (string-to-number pwsh-version) 0) "pwsh" "powershell")))
-      (if (or (>= (string-to-number powershell-version) 5) (string= powershell-binary "pwsh"))
+      (if (or (string= powershell-binary "pwsh") (>= (string-to-number powershell-version) 5))
           (call-process powershell-binary
                         nil
                         nil

--- a/lsp-mssql.el
+++ b/lsp-mssql.el
@@ -84,8 +84,7 @@ This is stored in the result buffer as buffer local value.")
                         nil
                         nil
                         "-command"
-                        (concat "add-type -assembly system.io.compression.filesystem;"
-                                "[io.compression.zipfile]::ExtractToDirectory(\"" filename "\", \"" target-dir "\")"))
+                        (concat "Expand-Archive \"" filename "\" \"" target-dir "\""))
 
         (message (concat "lsp-csharp: for automatic server installation procedure"
                          " to work on Windows you need to have powershell v5+ installed")))))

--- a/lsp-mssql.el
+++ b/lsp-mssql.el
@@ -74,7 +74,7 @@ This is stored in the result buffer as buffer local value.")
    ((eq system-type 'windows-nt)
     ;; on windows, we attempt to use powershell v5+, available on Windows 10+
     (let ((powershell-version (substring
-                               (shell-command-to-string "powershell -command \"(Get-Host).Version.Major\"")
+                               (shell-command-to-string "powershell -noprofile -command \"(Get-Host).Version.Major\"")
                                0 -1)))
       (if (>= (string-to-number powershell-version) 5)
           (call-process "powershell"

--- a/lsp-mssql.el
+++ b/lsp-mssql.el
@@ -75,8 +75,12 @@ This is stored in the result buffer as buffer local value.")
     ;; on windows, we attempt to use powershell v5+, available on Windows 10+
     (let ((powershell-version (substring
                                (shell-command-to-string "powershell -noprofile -command \"(Get-Host).Version.Major\"")
+                               0 -1))
+		  ;; Powershell v7+ uses a different binary
+		  (pwsh-version (substring
+                               (shell-command-to-string "pwsh -noprofile -command \"(Get-Host).Version.Major\"")
                                0 -1)))
-      (if (>= (string-to-number powershell-version) 5)
+      (if (or (>= (string-to-number powershell-version) 5) (>= (string-to-number pwsh-version) 5))
           (call-process "powershell"
                         nil
                         nil

--- a/lsp-mssql.el
+++ b/lsp-mssql.el
@@ -87,7 +87,7 @@ This is stored in the result buffer as buffer local value.")
                         nil
                         nil
                         "-command"
-                        (concat "Expand-Archive \"" filename "\" \"" target-dir "\""))
+                        (concat "-noprofile Expand-Archive \"" filename "\" \"" target-dir "\""))
 
         (message (concat "lsp-csharp: for automatic server installation procedure"
                          " to work on Windows you need to have powershell v5+ installed")))))


### PR DESCRIPTION
These changes add checks for PowerShell v7+ which uses a different binary (`pwsh.exe`) and uses it if available.

In addition, the `-noprofile` argument has been added to all PowerShell commands to avoid profile errors causing the version check(s) to fail. 